### PR TITLE
Fixed _check_required_channels error

### DIFF
--- a/cogs/moveusers.py
+++ b/cogs/moveusers.py
@@ -26,12 +26,12 @@ class MoveUsers(commands.Cog):
 
 
     # Helper function to check if all required channels for automove are fulfilled
-    def _check_required_channels(self, ctx):
+    def _check_required_channels(self):
         for req_channel in ["Lounge", "Study", "General", "Cinema"]:
             if req_channel not in DIFFERENT_NAME_CHANNELS:
                 return False
-        for channel_name in DIFFERENT_NAME_CHANNELS.values():
-            channel = discord.utils.get(ctx.guild.voice_channels, name=channel_name)
+        for channel_id in DIFFERENT_NAME_CHANNELS.values():
+            channel = self.bot.get_channel(channel_id)
             if not channel:
                 return False
         return True
@@ -54,7 +54,7 @@ class MoveUsers(commands.Cog):
     # Command function that auto moves users to various different channels depending on activities of all users in all voice channels
     @commands.command()
     async def automove(self, ctx):
-        if not self.check_required_channels(ctx):
+        if not self._check_required_channels():
             try:
                 with open("constantvariables.py", "r+") as file:
                     content = file.read()


### PR DESCRIPTION
- if statement was missing a _
- _check_required_channels function second for loop caused an error. was checking for the name of the channel but should've been checking for the channel ID. also incorrect variable name.