### PR TITLE
Fixed duplicate check_required_channels

### DIFF
--- a/cogs/moveusers.py
+++ b/cogs/moveusers.py
@@ -54,19 +54,6 @@ class MoveUsers(commands.Cog):
     # Command function that auto moves users to various different channels depending on activities of all users in all voice channels
     @commands.command()
     async def automove(self, ctx):
-        if not self._check_required_channels():
-            try:
-                with open("constantvariables.py", "r+") as file:
-                    content = file.read()
-                    updated_content = content.replace("AUTO_MOVE_FLAG = True", "AUTO_MOVE_FLAG = False")
-                    file.seek(0)
-                    file.write(updated_content)
-                    file.truncate()
-                print("Required channels for using auto move error. Set AUTO_MOVE_FLAG in constantvariables.py to False")
-                return
-            except Exception as e:
-                print("Error updating AUTO_MOVE_FLAG:", e)
-
         if AUTO_MOVE_FLAG:
             if not self.check_required_channels(ctx):
                 try:


### PR DESCRIPTION
Error with last PR:
The if statement to check for check_required_channels was added under auto_move_flag check but was not deleted above it
(This was due to a merge conflict)